### PR TITLE
feat: collect upstream api exceptions in a custom header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ wheels/
 .venv
 
 /docs/.ipynb_checkpoints/
+
+# Execution plans
+dev-docs/plans/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection-search-only STAC API that aggregates collection search results from
 - Supports standard STAC collection search parameters (bbox, datetime, limit, fields, sortby, filter, free text)
 - Token-based pagination across multiple APIs
 - Health check endpoint for monitoring upstream API availability and collection-search capability
+- Graceful handling of upstream API failures with the `strict` query parameter. When `strict=false` (default), failed upstream APIs are skipped and the problematic URLs are returned in the `X-Failed-Upstream-Apis` response header. When `strict=true`, the search fails fast if any upstream API errors.
 
 ## Running it locally
 

--- a/dev-docs/specs/upstream-error-handling.md
+++ b/dev-docs/specs/upstream-error-handling.md
@@ -1,0 +1,317 @@
+# Spec: Graceful Upstream API Failure Handling
+
+## Context
+
+The `stac-fastapi-collection-discovery` application federates collection-search
+requests across multiple upstream STAC APIs. Currently, if any single upstream API
+request in `all_collections()` raises an exception (network error, timeout, 5xx,
+malformed response), the entire search fails. The `conformance_classes()` and
+`health_check()` endpoints already handle individual API failures gracefully,
+using per-task exception catching. The goal is to apply the same resilience to
+the search path.
+
+This spec must remain conformant with the STAC API specification, which defines
+the `/collections` response as a `Collections` object containing `collections`,
+`links`, and optional `numberReturned`/`numberMatched` fields.
+
+## Goals
+
+- **Primary:** Ensure that a single upstream API failure does not cause the
+  entire federated search to fail.
+- **Secondary:** Provide observability into which upstream APIs failed via
+  structured logging.
+- **Tertiary:** Communicate upstream failures to the client via an HTTP response
+  header without breaking STAC API conformance.
+- **Non-goal:** Implement automatic retry logic for transient failures (can be
+  added later without breaking changes).
+- **Non-goal:** Add retry logic.
+- **Non-goal:** Change the behavior of `conformance_classes()` or
+  `health_check()` (they already handle failures correctly).
+
+## Constraints & Assumptions
+
+- The STAC API Collection Search spec (OGC API - Features / STAC API Collections)
+  does not define a standard way to communicate partial upstream failures in the
+  response body. The response must remain a valid `Collections` object.
+- The `Collections` model from `stac_pydantic` supports optional `numberReturned`
+  and `numberMatched` fields.
+- Pagination state is maintained via base64-encoded tokens that track the current,
+  previous, and next URLs for each upstream API.
+- The application is built on `stac-fastapi`, which wraps client return values in
+  FastAPI responses. Adding custom HTTP headers requires returning a
+  `fastapi.Response` (or subclass) from the endpoint rather than a plain model.
+- A `strict` query parameter on `GET /collections` controls fail-fast vs
+  graceful-degradation behavior.
+
+## Architecture Overview
+
+The change is localized to the `fetch_api_data` logic within
+`CollectionSearchClient.all_collections()`. Instead of using `asyncio.gather()`
+with the default behavior (first exception aborts all), we use
+`return_exceptions=True` and inspect each result individually.
+
+```
++--------------+     +----------------+     +--------------------+
+| GET /collections  |---->| all_collections |-->| Fetch from API 1   |
+| ?strict=false     |     |                |     | Fetch from API 2   |
++--------------+     +----------------+     | Fetch from API 3   |
+                                            +--------------------+
+                                                       |
+                                                       v
+                                            +--------------------+
+                                            | Gather with        |
+                                            | return_exceptions=True|
+                                            +--------------------+
+                                                       |
+                                    +------------------+--+------------------+
+                                    v                     v                     v
+                              +----------+        +----------+          +----------+
+                              | Success  |        | Success  |          | Failure  |
+                              | (include)|        | (include)|          | (skip)   |
+                              +----------+        +----------+          +----------+
+                                    |                     |                     |
+                                    +---------------------+---------------------+
+                                                          v
+                                            +--------------------+
+                                            | Merge collections  |
+                                            | Merge pagination   |
+                                            | Return Collections |
+                                            | + X-Failed-... hdr |
+                                            +--------------------+
+```
+
+## Detailed Design
+
+### `GET /collections` Parameters
+
+| Parameter | Type   | Default | Description |
+|-----------|--------|---------|-------------|
+| `strict`  | `bool` | `false` | When `true`, the entire search fails if any upstream API returns an error or times out. When `false`, failed APIs are skipped, a warning is logged, and their URLs are returned in a response header. |
+
+All other existing query parameters (`bbox`, `datetime`, `limit`, `q`, `token`,
+etc.) remain unchanged.
+
+### Response Headers
+
+| Header | Value | Condition |
+|--------|-------|-----------|
+| `X-Failed-Upstream-Apis` | Comma-separated list of failed API URLs | Present when `strict=false` and at least one upstream API failed. Omitted when all APIs succeeded. |
+
+Example:
+
+```
+X-Failed-Upstream-Apis: https://unhealthy.api.example.com/collections
+```
+
+### Error Handling Behavior
+
+For each upstream API request:
+
+1. **HTTP 2xx with valid JSON:** Include the collections in the result. Extract
+   `next` and `previous` links for pagination state.
+2. **HTTP 4xx/5xx:** Log a warning with the API URL, status code, and response
+   body (truncated). Skip this API's collections. Do not include this API in the
+   pagination state for subsequent pages.
+3. **Network error / timeout:** Log a warning with the API URL and exception.
+   Skip this API's collections. Do not include this API in the pagination state.
+4. **Malformed JSON response:** Log a warning. Skip this API's collections.
+5. **All APIs fail:** Return a valid `Collections` object with an empty
+   `collections` array, `numberReturned: 0`, and only a `self` link.
+
+When `strict=true`, any of the above failure conditions (2-4) immediately raise
+an error and abort the entire search, preserving the current behavior.
+
+### Pagination State for Failed APIs
+
+The token state structure is:
+
+```python
+{
+    "current": {"api1": "url1", "api2": "url2"},
+    "previous": {"api1": "prev1"},
+    "next": {"api1": "next1", "api2": "next2"},
+    "is_first_page": bool,
+}
+```
+
+When an API fails (in non-strict mode):
+- Do **not** add it to `new_state["current"]` (it has no current page).
+- Do **not** add it to `new_state["previous"]` (we don't know its previous link).
+- Do **not** add it to `new_state["next"]` (we don't want to query it again).
+
+This means a failed API is effectively dropped from the federated search for the
+remainder of the pagination session. If the user wants to retry, they must start
+a fresh search (omit the `token` parameter). This keeps the token state compact
+and avoids retrying known-bad APIs on every page.
+
+### Logging
+
+Each failure is logged at `WARNING` level with a structured message:
+
+```python
+logger.warning(
+    f"Upstream API returned error status: {api=}, {url=}, "
+    f"status_code={api_response.status_code}, "
+    f"response_body={api_response.text[:500]}"
+)
+```
+
+and for exceptions:
+
+```python
+logger.warning(f"Upstream API request failed: {api=}, {url=}, error={e}")
+```
+
+### Response Fields
+
+- **`collections`:** Only includes collections from successfully queried APIs.
+- **`links`:** Standard STAC links (`self`, optional `next`, optional `previous`)
+  plus `canonical` links for each successful API.
+- **`numberReturned`:** Count of collections from successful APIs only.
+- **`numberMatched`:** **Omitted.** Since upstream APIs may or may not return
+  this, and we can't accurately compute it when some APIs fail, we omit it
+  entirely rather than return a misleading value.
+
+## API / Interface Design
+
+### Public API Changes
+
+The `GET /collections` endpoint gains an optional `strict` query parameter. The
+response body remains a valid STAC `Collections` object; failed upstream APIs
+are communicated via the `X-Failed-Upstream-Apis` response header.
+
+### How to inject headers
+
+`stac-fastapi`'s `create_async_endpoint()` returns a Pydantic model (or dict),
+and FastAPI serializes it into a response via the route's `response_class`.
+This gives us no hook to add headers. The cleanest approach is to bypass
+`create_async_endpoint()` entirely for `/collections` and write a custom
+endpoint that returns a `JSONResponse` directly.
+
+We override `register_get_collections()` in `StacCollectionSearchApi`. The
+override defines its own endpoint `async def get_collections(request, ...)` that:
+1. Accepts the request model via `Depends(...)`.
+2. Calls `self.client.all_collections(...)` directly.
+3. Converts the `Collections` result to a JSON-serializable dict.
+4. Returns `JSONResponse(content=body, headers={"X-Failed-Upstream-Apis": ...})`.
+
+The route still declares `response_model=Collections` so OpenAPI documentation
+and client generators remain accurate. FastAPI skips `response_model`
+serialization when the endpoint already returns a `Response` subclass.
+
+## Data Model
+
+### `CollectionSearchResult`
+
+A new internal dataclass to convey both the search results and failure
+metadata:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class CollectionSearchResult:
+    collections: Collections
+    failed_apis: list[str]
+```
+
+No other data model changes.
+
+## Integration Points
+
+- **`FederatedApisGetRequest`:** New `strict` field added to the request model.
+- **`StacCollectionSearchApi.register_get_collections`:** Fully overridden to
+  define a custom endpoint that returns `JSONResponse` directly, bypassing
+  `create_async_endpoint()`. This lets us attach the `X-Failed-Upstream-Apis`
+  header while keeping `response_model=Collections` for OpenAPI docs.
+- **Logging:** Integrates with the standard library `logging` already used
+  throughout the module.
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **One API fails, others succeed (strict=false):**
+   - Mock 3 APIs: 2 return 200, 1 returns 500.
+   - Verify the result contains collections from the 2 successful APIs.
+   - Verify `numberReturned` reflects only successful API collections.
+   - Verify the failed API is not in `new_state["next"]`.
+   - Verify `failed_apis` list contains the failed API URL.
+
+2. **Strict mode enabled (strict=true):**
+   - Mock 2 APIs: one returns 500, one returns 200.
+   - Verify the search raises an exception (fail-fast behavior).
+
+3. **All APIs fail with strict=false:**
+   - Mock all configured APIs to return 5xx.
+   - Verify the result is a valid `Collections` with empty `collections` and
+     `numberReturned: 0`.
+   - Verify `failed_apis` contains all API URLs.
+
+4. **Network timeout:**
+   - Mock one API to raise `httpx.TimeoutException`.
+   - Verify search continues with remaining APIs.
+   - Verify failed API appears in `failed_apis`.
+
+5. **Malformed JSON:**
+   - Mock one API to return 200 with invalid JSON.
+   - Verify search continues and the failure is logged.
+   - Verify failed API appears in `failed_apis`.
+
+6. **Pagination with failed API:**
+   - First page: 3 APIs, 1 fails. Verify `next` token only contains 2 APIs.
+   - Second page (using token): Verify only 2 APIs are queried.
+   - Verify `failed_apis` is empty on the second page if none fail.
+
+7. **Empty result from healthy API:**
+   - One API returns 200 with empty `collections` array.
+   - Verify it is handled correctly (no exception, included in state if it has
+     a next link).
+
+### Integration Tests
+
+- Test against real APIs by temporarily blocking one via firewall/mock to verify
+  the application doesn't crash.
+- Verify `X-Failed-Upstream-Apis` header appears in the HTTP response when an
+  upstream API fails.
+
+### App-level Tests
+
+- Test the FastAPI endpoint directly using `TestClient`:
+  - Request with `?strict=false` and a mocked failing API → verify 200 with
+    header.
+  - Request with `?strict=true` and a mocked failing API → verify error status.
+  - Request with no `strict` param (default) → verify graceful handling.
+
+## Decision Log
+
+| Decision | Options Considered | Rationale |
+|----------|-------------------|-----------|
+| Exclude failed APIs from pagination state | Continue including failed APIs in state for retry; Add retry logic | Dropping failed APIs keeps tokens small and avoids repeated failures. Retry logic can be added later as a separate feature. |
+| HTTP header for failed APIs | Add `failed_apis` field to response body; Add HTTP headers | Header preserves strict STAC API conformance. Body field is simpler for clients to parse but risks validation failures with strict STAC validators. The header keeps the payload clean. |
+| Per-request `strict` parameter | Global setting only (`strict_upstream_mode`) | Per-request control allows clients to opt into fail-fast behavior when they need it (e.g., debugging), while keeping graceful handling as the production default. |
+| Omit `numberMatched` | Set `numberMatched` to sum of successful APIs only; Set to `None` | Without all upstream responses, we can't compute an accurate total. Omitting is more honest than a partial sum. |
+| No retry logic | Exponential backoff retry; Retry once immediately | Adds significant complexity. Can be added later without breaking changes. |
+| Return result dataclass from `all_collections` | Attach failures to request state; Use global context | Explicit return is clearer, easier to test, and avoids hidden side effects. |
+| Custom endpoint returning `JSONResponse` | Middleware to inject headers; Custom response class subclass | Middleware adds complexity and runs for every route. Custom response class can't access per-request data. Returning `JSONResponse` directly from the endpoint is the simplest FastAPI-native approach. |
+
+## Open Questions
+
+1. Should we add request-level telemetry (e.g., Prometheus metrics) to track
+   upstream API failure rates? This could be a follow-up enhancement.
+2. Should we consider a circuit-breaker pattern if an API fails repeatedly
+   across requests?
+
+## Status
+
+- [x] Designing
+- [x] Approved — ready to plan
+- [x] Implementing
+- [x] Implemented
+
+## References
+
+- STAC API Collection Search spec: https://github.com/radiantearth/stac-api-spec/tree/main/collection-search
+- `stac_pydantic` Collections model
+- Existing `conformance_classes()` and `health_check()` implementations (already
+  handle per-API failures gracefully)

--- a/src/stac_fastapi/collection_discovery/app.py
+++ b/src/stac_fastapi/collection_discovery/app.py
@@ -4,22 +4,11 @@ from typing import Annotated, Dict, List, Optional
 
 import attr
 from brotli_asgi import BrotliMiddleware
-from fastapi import APIRouter, FastAPI, Query
-from stac_pydantic.api import Conformance, LandingPage
-from stac_pydantic.shared import MimeTypes
-from starlette.middleware import Middleware
-
+from fastapi import APIRouter, FastAPI, Query, Request
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
-from stac_fastapi.api.models import HealthCheck
+from stac_fastapi.api.models import HealthCheck, JSONResponse
 from stac_fastapi.api.routes import create_async_endpoint
-from stac_fastapi.collection_discovery import __version__
-from stac_fastapi.collection_discovery.core import (
-    COLLECTION_SEARCH_CONFORMANCE_CLASSES,
-    CollectionSearchClient,
-    health_check,
-)
-from stac_fastapi.collection_discovery.settings import Settings
 from stac_fastapi.extensions.core import (
     CollectionSearchExtension,
     CollectionSearchFilterExtension,
@@ -33,6 +22,17 @@ from stac_fastapi.extensions.core.free_text import FreeTextConformanceClasses
 from stac_fastapi.extensions.core.sort import SortConformanceClasses
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import APIRequest
+from stac_pydantic.api import Collections, Conformance, LandingPage
+from stac_pydantic.shared import MimeTypes
+from starlette.middleware import Middleware
+
+from stac_fastapi.collection_discovery import __version__
+from stac_fastapi.collection_discovery.core import (
+    COLLECTION_SEARCH_CONFORMANCE_CLASSES,
+    CollectionSearchClient,
+    health_check,
+)
+from stac_fastapi.collection_discovery.settings import Settings
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -90,6 +90,13 @@ position across all upstream APIs.
 
 @attr.s
 class FederatedApisGetRequest(APIRequest):
+    strict: Annotated[
+        bool,
+        Query(
+            description="If true, fail the entire request when any upstream API errors"
+        ),
+    ] = attr.ib(default=False)
+
     apis: Annotated[
         Optional[List[str]],
         Query(
@@ -196,6 +203,44 @@ class StacCollectionSearchApi(StacApi):
             ),
         )
 
+    def register_get_collections(self) -> None:
+        """Register get collections endpoint (GET /collections) with custom response
+        to inject X-Failed-Upstream-Apis header."""
+
+        async def get_collections(request: Request, **kwargs) -> JSONResponse:
+            """Custom collections endpoint that injects failure header."""
+            result = await self.client.all_collections(request=request, **kwargs)
+            body = result.collections
+            headers = {}
+            if result.failed_apis:
+                headers["X-Failed-Upstream-Apis"] = ",".join(result.failed_apis)
+
+            return JSONResponse(content=body, headers=headers)
+
+        self.router.add_api_route(
+            name="Get Collections",
+            path="/collections",
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Collections,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(  # type: ignore[arg-type]
+                get_collections,
+                collections_get_request_model,  # type: ignore[arg-type]
+            ),
+        )
+
     def add_health_check(self) -> None:
         """Add a health check with the apis parameter enabled."""
 
@@ -263,7 +308,7 @@ api = StacCollectionSearchApi(
         base_conformance_classes=COLLECTION_SEARCH_CONFORMANCE_CLASSES
     ),
     settings=settings,
-    collections_get_request_model=collections_get_request_model,
+    collections_get_request_model=collections_get_request_model,  # type: ignore[arg-type]
     health_check=health_check,
     middlewares=[
         Middleware(BrotliMiddleware),

--- a/src/stac_fastapi/collection_discovery/app.py
+++ b/src/stac_fastapi/collection_discovery/app.py
@@ -319,6 +319,7 @@ api = StacCollectionSearchApi(
             allow_credentials=True,
             allow_methods=settings.cors_methods,
             allow_headers=["*"],
+            expose_headers=["X-Failed-Upstream-Apis"],
         ),
     ],
 )

--- a/src/stac_fastapi/collection_discovery/core.py
+++ b/src/stac_fastapi/collection_discovery/core.py
@@ -2,16 +2,14 @@ import asyncio
 import base64
 import json
 import logging
+from dataclasses import dataclass
 from typing import Annotated, Any
 from urllib.parse import unquote, urlencode, urljoin
 
 import attr
 from fastapi import HTTPException, Query, Request
-from httpx import AsyncClient
+from httpx import AsyncClient, HTTPStatusError
 from pydantic import BaseModel
-from stac_pydantic.links import Relations
-from stac_pydantic.shared import BBox, MimeTypes
-
 from stac_fastapi.types.conformance import OAFConformanceClasses, STACConformanceClasses
 from stac_fastapi.types.core import AsyncBaseCoreClient
 from stac_fastapi.types.requests import get_base_url
@@ -22,6 +20,8 @@ from stac_fastapi.types.stac import (
     ItemCollection,
     LandingPage,
 )
+from stac_pydantic.links import Relations
+from stac_pydantic.shared import BBox, MimeTypes
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +90,14 @@ class HealthCheckResponse(BaseModel):
     status: str
     lifespan: LifespanStatus
     upstream_apis: dict[str, UpstreamApiStatus]
+
+
+@dataclass
+class CollectionSearchResult:
+    """Internal result wrapper for collection search."""
+
+    collections: Collections
+    failed_apis: list[str]
 
 
 class CollectionSearchClient(AsyncBaseCoreClient):
@@ -222,11 +230,12 @@ class CollectionSearchClient(AsyncBaseCoreClient):
                 logger.warning(f"Error fetching conformance from {api}: {e}")
                 return api, set()
 
-    async def all_collections(
+    async def all_collections(  # type: ignore[override]
         self,
         request: Request,
         apis: list[str] | None = None,
         token: str | None = None,
+        strict: bool = False,
         bbox: BBox | None = None,
         datetime: str | None = None,
         limit: int | None = None,
@@ -236,8 +245,8 @@ class CollectionSearchClient(AsyncBaseCoreClient):
         filter_lang: str | None = None,
         q: list[str] | None = None,
         **kwargs,
-    ) -> Collections:
-        """Collection search for multiple upstream APIs"""
+    ) -> CollectionSearchResult:
+        """Collection search for multiple upstream APIs."""
         # When using token pagination, apis are encoded in the token
         # Only validate apis parameter when not using token
         if not token:
@@ -251,6 +260,7 @@ class CollectionSearchClient(AsyncBaseCoreClient):
 
         collections = []
         canonical_links = []
+        failed_apis: list[str] = []
 
         new_state: dict[str, Any] = {
             "current": {},
@@ -278,10 +288,31 @@ class CollectionSearchClient(AsyncBaseCoreClient):
                 fetch_api_data(client, api, url) for api, url in current_urls.items()
             ]
 
-            api_responses = await asyncio.gather(*tasks)
+            api_responses = await asyncio.gather(*tasks, return_exceptions=True)
 
-            for api, json_response in api_responses:
+            for api, result in zip(current_urls.keys(), api_responses, strict=True):
                 url = current_urls[api]
+
+                if isinstance(result, Exception):
+                    if strict:
+                        raise result
+
+                    if isinstance(result, HTTPStatusError):
+                        response = result.response
+                        logger.warning(
+                            f"Upstream API returned error status: {api=}, {url=}, "
+                            f"status_code={response.status_code}, "
+                            f"response_body={response.text[:500]}"
+                        )
+                    else:
+                        logger.warning(
+                            f"Upstream API request failed: {api=}, {url=}, error={result}"
+                        )
+                    failed_apis.append(api)
+                    continue
+
+                assert isinstance(result, tuple)
+                json_response = result[1]
                 collections_count = len(json_response["collections"])
                 logger.info(f"Received {collections_count} collections from {api}")
 
@@ -313,13 +344,16 @@ class CollectionSearchClient(AsyncBaseCoreClient):
         links = self._build_pagination_links(request, search_state, new_state)
         links.extend(canonical_links)
 
-        return Collections(
-            collections=collections,
-            links=links,
-            numberReturned=len(collections),
+        return CollectionSearchResult(
+            collections=Collections(
+                collections=collections,
+                links=links,
+                numberReturned=len(collections),
+            ),
+            failed_apis=failed_apis,
         )
 
-    async def landing_page(
+    async def landing_page(  # type: ignore[override]
         self, request: Request, apis: list[str] | None = None, **kwargs
     ) -> LandingPage:
         """Landing page.
@@ -428,7 +462,7 @@ class CollectionSearchClient(AsyncBaseCoreClient):
 
         return LandingPage(**landing_page)
 
-    async def conformance_classes(
+    async def conformance_classes(  # type: ignore[override]
         self, request: Request, apis: list[str] | None = None
     ) -> list[str]:
         """Generate conformance classes by finding intersection of local and upstream API
@@ -494,7 +528,7 @@ class CollectionSearchClient(AsyncBaseCoreClient):
 
         return sorted(result_set)
 
-    async def conformance(
+    async def conformance(  # type: ignore[override]
         self, request: Request, apis: list[str] | None, **kwargs
     ) -> dict[str, list[str]]:
         """Conformance classes endpoint.
@@ -533,6 +567,7 @@ async def health_check(
         list[str] | None,
         Query(description="List of STAC APIs to check health status for"),
     ] = None,
+    **kwargs,
 ) -> HealthCheckResponse:
     """PgSTAC HealthCheck."""
     apis = _resolve_apis(apis, request)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -358,3 +358,64 @@ class TestApp:
         conformance_classes = data["conformsTo"]
         assert any("core" in cls for cls in conformance_classes)
         assert any("collections" in cls for cls in conformance_classes)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_collections_endpoint_with_failed_upstream(
+        self, client, sample_collections_response
+    ):
+        """Test that failed upstream API is reported via header."""
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(500, json={"error": "boom"})
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
+        response = client.get("/collections")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "collections" in data
+        assert len(data["collections"]) == 2
+        assert "X-Failed-Upstream-Apis" in response.headers
+        assert "https://api1.example.com" in response.headers["X-Failed-Upstream-Apis"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_collections_endpoint_strict_mode(
+        self, client, sample_collections_response
+    ):
+        """Test that strict=true causes error when upstream API fails."""
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(500, json={"error": "boom"})
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
+        # strict=True propagates the upstream exception through the endpoint
+        from httpx import HTTPStatusError
+
+        with pytest.raises(HTTPStatusError):
+            client.get("/collections?strict=true")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_collections_endpoint_no_failed_header_when_all_healthy(
+        self, client, sample_collections_response
+    ):
+        """Test that healthy upstreams don't produce failure header."""
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
+        response = client.get("/collections")
+
+        assert response.status_code == 200
+        assert "X-Failed-Upstream-Apis" not in response.headers
+        data = response.json()
+        assert len(data["collections"]) == 4

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -60,22 +60,26 @@ class TestCollectionSearchClient:
         result = await collection_search_client.all_collections(request=mock_request)
 
         # Should have collections from both APIs
-        assert len(result["collections"]) == 4
-        assert result["numberReturned"] == 4
+        assert len(result.collections["collections"]) == 4
+        assert result.collections["numberReturned"] == 4
 
         # Check collection IDs
-        collection_ids = [c["id"] for c in result["collections"]]
+        collection_ids = [c["id"] for c in result.collections["collections"]]
         assert "api1-collection-1" in collection_ids
         assert "api1-collection-2" in collection_ids
         assert "api2-collection-1" in collection_ids
         assert "api2-collection-2" in collection_ids
 
         # Check links
-        self_link = next(link for link in result["links"] if link["rel"] == "self")
+        self_link = next(
+            link for link in result.collections["links"] if link["rel"] == "self"
+        )
         assert self_link["href"] == str(mock_request.url)
 
         # Should have canonical links to both APIs
-        canonical_links = [link for link in result["links"] if link["rel"] == "canonical"]
+        canonical_links = [
+            link for link in result.collections["links"] if link["rel"] == "canonical"
+        ]
         assert len(canonical_links) == 2
 
     @pytest.mark.asyncio
@@ -105,7 +109,7 @@ class TestCollectionSearchClient:
 
         # Should have next link
         next_link = next(
-            (link for link in result["links"] if link["rel"] == "next"), None
+            (link for link in result.collections["links"] if link["rel"] == "next"), None
         )
         assert next_link is not None
         assert "token=" in next_link["href"]
@@ -138,8 +142,8 @@ class TestCollectionSearchClient:
             request=mock_request, token=token
         )
 
-        assert len(result["collections"]) == 4
-        assert result["numberReturned"] == 4
+        assert len(result.collections["collections"]) == 4
+        assert result.collections["numberReturned"] == 4
 
     @pytest.mark.asyncio
     @respx.mock
@@ -161,17 +165,15 @@ class TestCollectionSearchClient:
             limit=10,
         )
 
-        assert len(result["collections"]) == 4
-        assert result["numberReturned"] == 4
+        assert len(result.collections["collections"]) == 4
+        assert result.collections["numberReturned"] == 4
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_all_collections_api_error(
+    async def test_all_collections_api_error_strict_false(
         self, collection_search_client, mock_request, sample_collections_response
     ):
-        """Test handling of API errors."""
-        from httpx import HTTPStatusError
-
+        """Test that one failing API doesn't crash when strict=False (default)."""
         # One API returns error, one succeeds
         respx.get("https://api1.example.com/collections").mock(
             return_value=Response(500, json={"error": "Internal server error"})
@@ -180,9 +182,40 @@ class TestCollectionSearchClient:
             return_value=Response(200, json=sample_collections_response)
         )
 
-        # Should raise exception due to failed API call
+        result = await collection_search_client.all_collections(request=mock_request)
+
+        # Should only have collections from api2
+        assert len(result.collections["collections"]) == 2
+        assert result.collections["numberReturned"] == 2
+        assert result.failed_apis == ["https://api1.example.com"]
+
+        # Verify state only contains api2
+        for link in result.collections["links"]:
+            if link["rel"] in ("next", "previous"):
+                decoded = collection_search_client._decode_token(
+                    link["href"].split("token=")[1]
+                )
+                assert "https://api1.example.com" not in decoded["current"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_api_error_strict_true(
+        self, collection_search_client, mock_request, sample_collections_response
+    ):
+        """Test that one failing API raises when strict=True."""
+        from httpx import HTTPStatusError
+
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(500, json={"error": "Internal server error"})
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
         with pytest.raises(HTTPStatusError):
-            await collection_search_client.all_collections(request=mock_request)
+            await collection_search_client.all_collections(
+                request=mock_request, strict=True
+            )
 
     @pytest.mark.asyncio
     @respx.mock
@@ -211,13 +244,15 @@ class TestCollectionSearchClient:
         )
 
         # Should only have collections from the specified APIs
-        assert len(result["collections"]) == 4  # 2 collections per API
-        collection_ids = [c["id"] for c in result["collections"]]
+        assert len(result.collections["collections"]) == 4  # 2 collections per API
+        collection_ids = [c["id"] for c in result.collections["collections"]]
         assert "api3-collection-1" in collection_ids
         assert "api4-collection-1" in collection_ids
 
         # Should have canonical links to both specified APIs
-        canonical_links = [link for link in result["links"] if link["rel"] == "canonical"]
+        canonical_links = [
+            link for link in result.collections["links"] if link["rel"] == "canonical"
+        ]
         assert len(canonical_links) == 2
 
     @pytest.mark.asyncio
@@ -236,11 +271,13 @@ class TestCollectionSearchClient:
         )
 
         # Should have collections from only one API
-        assert len(result["collections"]) == 2
-        assert result["numberReturned"] == 2
+        assert len(result.collections["collections"]) == 2
+        assert result.collections["numberReturned"] == 2
 
         # Should have only one canonical link
-        canonical_links = [link for link in result["links"] if link["rel"] == "canonical"]
+        canonical_links = [
+            link for link in result.collections["links"] if link["rel"] == "canonical"
+        ]
         assert len(canonical_links) == 1
 
     @pytest.mark.asyncio
@@ -305,7 +342,7 @@ class TestCollectionSearchClient:
 
         # Should have next link
         next_link = next(
-            (link for link in result["links"] if link["rel"] == "next"), None
+            (link for link in result.collections["links"] if link["rel"] == "next"), None
         )
         assert next_link is not None
         assert "token=" in next_link["href"]
@@ -328,8 +365,8 @@ class TestCollectionSearchClient:
             limit=5,
         )
 
-        assert len(result["collections"]) == 2
-        assert result["numberReturned"] == 2
+        assert len(result.collections["collections"]) == 2
+        assert result.collections["numberReturned"] == 2
 
     @pytest.mark.asyncio
     @respx.mock
@@ -409,7 +446,8 @@ class TestCollectionSearchClient:
 
         # Extract the next link and token from first page
         next_link = next(
-            (link for link in first_result["links"] if link["rel"] == "next"), None
+            (link for link in first_result.collections["links"] if link["rel"] == "next"),
+            None,
         )
         assert next_link is not None
         assert "token=" in next_link["href"]
@@ -431,9 +469,194 @@ class TestCollectionSearchClient:
         )
 
         # Should have collections from page 2
-        assert len(second_result["collections"]) == 1
-        collection_ids = [c["id"] for c in second_result["collections"]]
+        assert len(second_result.collections["collections"]) == 1
+        collection_ids = [c["id"] for c in second_result.collections["collections"]]
         assert "api3-page2-collection-1" in collection_ids
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_all_apis_fail_strict_false(
+        self, collection_search_client, mock_request
+    ):
+        """Test that all failing APIs returns empty collections with failed_apis."""
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(500, json={"error": "boom"})
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(503, json={"error": "down"})
+        )
+
+        result = await collection_search_client.all_collections(request=mock_request)
+
+        assert result.collections["collections"] == []
+        assert result.collections["numberReturned"] == 0
+        assert len(result.failed_apis) == 2
+        assert "https://api1.example.com" in result.failed_apis
+        assert "https://api2.example.com" in result.failed_apis
+
+        # Only self link
+        rels = {link["rel"] for link in result.collections["links"]}
+        assert rels == {"self"}
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_network_timeout(
+        self, collection_search_client, mock_request, sample_collections_response
+    ):
+        """Test that one timing-out API doesn't crash others."""
+        import httpx
+
+        respx.get("https://api1.example.com/collections").mock(
+            side_effect=httpx.TimeoutException("Connection timed out")
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
+        result = await collection_search_client.all_collections(request=mock_request)
+
+        assert len(result.collections["collections"]) == 2
+        assert result.failed_apis == ["https://api1.example.com"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_malformed_json(
+        self, collection_search_client, mock_request, sample_collections_response
+    ):
+        """Test that one malformed JSON response doesn't crash others."""
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(200, text="not-json")
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=sample_collections_response)
+        )
+
+        result = await collection_search_client.all_collections(request=mock_request)
+
+        assert len(result.collections["collections"]) == 2
+        assert result.failed_apis == ["https://api1.example.com"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_pagination_with_failed_api(
+        self, collection_search_client, mock_request, sample_collections_response
+    ):
+        """Test pagination state excludes failed APIs."""
+        import copy
+
+        api1_response = copy.deepcopy(sample_collections_response)
+        api1_response["links"] = [
+            {"rel": "self", "href": "https://api1.example.com/collections"},
+            {
+                "rel": "next",
+                "href": "https://api1.example.com/collections?page=2",
+            },
+        ]
+
+        api2_response = copy.deepcopy(sample_collections_response)
+        api2_response["links"] = [
+            {"rel": "self", "href": "https://api2.example.com/collections"},
+        ]
+
+        # api3 fails with 500
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(200, json=api1_response)
+        )
+        respx.get("https://api2.example.com/collections").mock(
+            return_value=Response(200, json=api2_response)
+        )
+        respx.get("https://api3.example.com/collections").mock(
+            return_value=Response(500, json={"error": "boom"})
+        )
+
+        result = await collection_search_client.all_collections(
+            request=mock_request,
+            apis=[
+                "https://api1.example.com",
+                "https://api2.example.com",
+                "https://api3.example.com",
+            ],
+        )
+
+        assert len(result.collections["collections"]) == 4
+        assert "https://api3.example.com" in result.failed_apis
+
+        # Next token should only include api1 (the one with a next link)
+        next_link = next(
+            (link for link in result.collections["links"] if link["rel"] == "next"),
+            None,
+        )
+        assert next_link is not None
+        token = next_link["href"].split("token=")[1]
+        decoded = collection_search_client._decode_token(token)
+        assert "https://api3.example.com" not in decoded["current"]
+        assert "https://api1.example.com" in decoded["current"]
+        # api2 didn't have a next link so won't be in next page's state
+        assert "https://api2.example.com" not in decoded["current"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_empty_result_with_next_link(
+        self, collection_search_client, mock_request
+    ):
+        """Test that empty collections with next link are handled correctly."""
+        response_data = {
+            "collections": [],
+            "links": [
+                {"rel": "self", "href": "https://api1.example.com/collections"},
+                {
+                    "rel": "next",
+                    "href": "https://api1.example.com/collections?page=2",
+                },
+            ],
+        }
+
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(200, json=response_data)
+        )
+
+        result = await collection_search_client.all_collections(
+            request=mock_request, apis=["https://api1.example.com"]
+        )
+
+        assert result.collections["collections"] == []
+        assert result.collections["numberReturned"] == 0
+        assert result.failed_apis == []
+
+        next_link = next(
+            (link for link in result.collections["links"] if link["rel"] == "next"),
+            None,
+        )
+        assert next_link is not None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_collections_empty_result_without_next_link(
+        self, collection_search_client, mock_request
+    ):
+        """Test that empty collections without next link ends pagination."""
+        response_data = {
+            "collections": [],
+            "links": [
+                {"rel": "self", "href": "https://api1.example.com/collections"},
+            ],
+        }
+
+        respx.get("https://api1.example.com/collections").mock(
+            return_value=Response(200, json=response_data)
+        )
+
+        result = await collection_search_client.all_collections(
+            request=mock_request, apis=["https://api1.example.com"]
+        )
+
+        assert result.collections["collections"] == []
+        assert result.collections["numberReturned"] == 0
+        next_link = next(
+            (link for link in result.collections["links"] if link["rel"] == "next"),
+            None,
+        )
+        assert next_link is None
 
     @pytest.mark.asyncio
     async def test_not_implemented_methods(self, collection_search_client):


### PR DESCRIPTION
Instead of failing when any upstream api request returns a 500, log the failed request and include the failing api in a new response header (`X-Failed-Upstream-Apis`). Also add a `strict` boolean query parameter to properly fail if any upstream api request fails.

With this change client applications can still get results even if one of the upstream APIs is out of order.

resolves #12
